### PR TITLE
Monkeypatch the watch() function

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,14 @@ module.exports = {
                     return original.apply(this);
                 }
 
+                function watch(original) {
+                    if (!initialized) {
+                        initializeWatcher(this, options);
+                        initialized = true;
+                    }
+                    return original.apply(this);
+                }
+
                 function serve(original, port) {
                     if (!initialized) {
                         initializeWatcher(this, options);
@@ -83,6 +91,7 @@ module.exports = {
                     return original.apply(this, [port]);
                 }
                 monkeypatch(Eleventy, write);
+                monkeypatch(Eleventy, watch);
                 monkeypatch(Eleventy, serve);
             }
         });


### PR DESCRIPTION
While working on my previous PR, I was trying to use `eleventy --watch` to debug what I was doing, and I was a bit perplexed at why changes to my watched files wouldn't ever trigger a rebuild -- but then I realized `watch()` wasn't getting monkeypatched, only `write()` and `serve()`. So I added one for `watch()` too, and now it works like you'd expect.