### PR TITLE
Added node-sass options and version bump

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const defaultOptions = {
     sourcemaps: false,
     cleanCSS: true,
     cleanCSSOptions: {},
+    sassOptions: {},
     autoprefixer: true,
     outputDir: undefined,
     remap: false
@@ -39,7 +40,7 @@ const compileSass = _debounce(function(eleventyInstance, options) {
     console.log(`[${chalk.red(PLUGIN_NAME)}] Compiling sass files...`);
     vfs.src(options.watch)
         .pipe(gulpIf(options.sourcemaps, sourcemaps.init()))
-        .pipe(sass().on('error', sass.logError))
+        .pipe(sass(options.sassOptions).on('error', sass.logError))
         .pipe(gulpIf(options.autoprefixer, prefix()))
         .pipe(gulpIf(options.cleanCSS, cleanCSS(options.cleanCSSOptions)))
         .pipe(gulpIf(options.sourcemaps, sourcemaps.write('.')))

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "homepage": "https://github.com/Sonaryr/eleventy-plugin-sass",
     "peerDependencies": {
-        "@11ty/eleventy": "^0.9.0"
+        "@11ty/eleventy": "^0.x"
     },
     "dependencies": {
         "chalk": "^2.4.2",


### PR DESCRIPTION
The main goal here is to add options to `gulp-sass`/`node-sass`, so you can e.g. add the following option:

```js
  sassOptions: {
     includePaths: ['node_modules/']
  }
```
When that is possible, you can do something like:
```sass
   @import 'node_modules/picnic/src/picnic'
```

This greatly improves the ability to work with CSS frameworks like Bootstrap. No idea how you'd have to do it otherwise.

Note that many people will try to use `@import '~bootstrap[...]'` style imports as well. This does not seem to work yet and may require something like [node-sass-magic-importer](https://github.com/maoberlehner/node-sass-magic-importer).

The other fix eliminates unnecessary warnings for 11th versions 0.10.x and 0.11.0.
