### PR TITLE
update gulp-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "gulp-autoprefixer": "^7.0.1",
         "gulp-clean-css": "^4.2.0",
         "gulp-if": "^3.0.0",
-        "gulp-sass": "^4.0.2",
+        "gulp-sass": "^5.0.0",
         "gulp-sourcemaps": "^2.6.5",
         "lodash.debounce": "^4.0.8",
         "map-stream": "^0.0.7",


### PR DESCRIPTION
updating the gulp-sass version to 5.0.0 resolves errors that arise from the deprecated node-sass dependency