### PR TITLE
Ensure BrowserSync only reloads the changed CSS files (much faster), not the entire page.

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const compileSass = _debounce(function(eleventyInstance, options) {
         .pipe(vfs.dest( (options.outputDir || eleventyInstance.outputDir), {nodir: true} ))
         .on('end', function() {
             console.log(`[${chalk.red(PLUGIN_NAME)}] Done compiling Sass files`);
-            eleventyInstance.eleventyServe.reload();
+            eleventyInstance.eleventyServe.reload('*.css');
         });
 }, 500);
 


### PR DESCRIPTION
Ensures that BrowserSync only reloads the changed CSS files (much faster), not the entire page. Since this plugin is able to explicitly watch just the SASS/SCSS files and only changes `*.css` files, it should just take advantage of BrowserSync's ability to quickly swap out with the new `*.css` files without a full page reload! 😄 

---

**To test:**

```
npm i "git+https://github.com/patricknelson/eleventy-plugin-sass.git#reload-only-css"
```

**To test all outstanding PR's:** (#32, #33 and #34)

```
npm i "git+https://github.com/patricknelson/eleventy-plugin-sass.git#dev"
```
