### PR TITLE
Add ability to customize error handler in gulp-sass.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,17 @@ Read more about [Eleventy plugins.](https://www.11ty.io/docs/plugins/)
 
 ## Options
 
-| Key               | Type                   | Default                                    | description                                                                                                       |
-| ----------------- | ---------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `watch`           | glob or array of globs | `['**/*.{scss,sass}', '!node_modules/**']` | The sass files you wish to compile (and watch when you serve)                                                     |
-| `sourcemaps`      | Boolean                | `false`                                    | Add sourcemaps next to your sass files                                                                            |
-| `cleanCSS`        | Boolean                | `true`                                     | Runs the css trough [cleanCSS](https://github.com/jakubpawlowicz/clean-css)                                       |
-| `cleanCSSOptions` | Object                 | `N/A`                                      | Options to pass to cleanCSS                                                                                       |
-| `autoprefixer`    | Boolean                | `true`                                     | Adds browser specific prefixes if needed (adheres to [BrowserList](https://github.com/browserslist/browserslist)) |
-| `outputDir`       | String                 | undefined                                  | specifies the desired output directory |
+| Key               | Type                   | Default                                    | description                                                                                                                               |
+| ----------------- | ---------------------- |--------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `watch`           | glob or array of globs | `['**/*.{scss,sass}', '!node_modules/**']` | The sass files you wish to compile (and watch when you serve)                                                                             |
+| `sourcemaps`      | Boolean                | `false`                                    | Add sourcemaps next to your sass files                                                                                                    |
+| `cleanCSS`        | Boolean                | `true`                                     | Runs the css trough [cleanCSS](https://github.com/jakubpawlowicz/clean-css)                                                               |
+| `cleanCSSOptions` | Object                 | `N/A`                                      | Options to pass to cleanCSS                                                                                                               |
+| `autoprefixer`    | Boolean                | `true`                                     | Adds browser specific prefixes if needed (adheres to [BrowserList](https://github.com/browserslist/browserslist))                         |
+| `outputDir`       | String                 | undefined                                  | specifies the desired output directory                                                                                                    |
 | `remap`           | Boolean                | false                                      | toggles the way EPS handles the output or better omits the path-part of each parsed file, so that you might get a slightly cleaner output |
-| `sassOptions`     | Object                 | `N/A`                                      | Options you want to pass to [node-sass](https://github.com/sass/node-sass#options) |
+| `onError`         | Callback               | `sass.logError`                            | Override the default `gulp-sass` error handler to a custom one.                                                                           |
+| `sassOptions`     | Object                 | `N/A`                                      | Options you want to pass to [node-sass](https://github.com/sass/node-sass#options)                                                        |
 
 ## Disclaimer
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ const defaultOptions = {
     sassOptions: {},
     autoprefixer: true,
     outputDir: undefined,
-    remap: false
+    remap: false,
+    onError: null,
 };
 
 function monkeypatch(cls, fn) {
@@ -40,7 +41,7 @@ const compileSass = _debounce(function(eleventyInstance, options) {
     console.log(`[${chalk.red(PLUGIN_NAME)}] Compiling Sass files...`);
     vfs.src(options.watch)
         .pipe(gulpIf(options.sourcemaps, sourcemaps.init()))
-        .pipe(sass(options.sassOptions).on('error', sass.logError))
+        .pipe(sass(options.sassOptions).on('error', options.onError || sass.logError))
         .pipe(gulpIf(options.autoprefixer, prefix()))
         .pipe(gulpIf(options.cleanCSS, cleanCSS(options.cleanCSSOptions)))
         .pipe(gulpIf(options.sourcemaps, sourcemaps.write('.')))


### PR DESCRIPTION
Adds the ability to customize error handler in gulp-sass. In my case, I really wanted to add a bell notification sound whenever there's an error/failure. Might also have some potential to leverage this to integrate into [`eleventy-plugin-error-overlay`](https://github.com/stevenpetryk/eleventy-plugin-error-overlay) (see discussion at https://github.com/11ty/eleventy/issues/525#issuecomment-1066331115).

---

**To test:**

```
npm i "git+https://github.com/patricknelson/eleventy-plugin-sass.git#custom-error-handler"
```

**To test all outstanding PR's:** (#32, #33 and #34)

```
npm i "git+https://github.com/patricknelson/eleventy-plugin-sass.git#dev"
```
